### PR TITLE
#31: bugfix AlreadyDisposedException

### DIFF
--- a/src/main/java/saigonwithlove/ivy/intellij/settings/IvyModuleListener.java
+++ b/src/main/java/saigonwithlove/ivy/intellij/settings/IvyModuleListener.java
@@ -1,0 +1,47 @@
+package saigonwithlove.ivy.intellij.settings;
+
+import static saigonwithlove.ivy.intellij.settings.PreferenceService.State;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.ModuleListener;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import saigonwithlove.ivy.intellij.shared.IvyModule;
+import saigonwithlove.ivy.intellij.shared.Modules;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class IvyModuleListener implements ModuleListener {
+  @Override
+  public void moduleRemoved(@NotNull Project project, @NotNull Module module) {
+    PreferenceService preferenceService = project.getService(PreferenceService.class);
+    List<IvyModule> initialModulesCopy =
+        new ArrayList<>(preferenceService.getState().getIvyModules());
+    List<IvyModule> remainingModules =
+        initialModulesCopy.stream()
+            .filter(item -> !item.getName().equalsIgnoreCase(module.getName()))
+            .collect(Collectors.toList());
+    preferenceService.update(
+        (state -> {
+          state.setIvyModules(remainingModules);
+          return state;
+        }));
+  }
+
+  @Override
+  public void moduleAdded(@NotNull Project project, @NotNull Module module) {
+    Optional<IvyModule> importModule = Modules.toIvyModule(module);
+    if (importModule.isPresent()) {
+      PreferenceService preferenceService = project.getService(PreferenceService.class);
+      List<IvyModule> allModules = new ArrayList<>(preferenceService.getState().getIvyModules());
+      allModules.add(importModule.get());
+      preferenceService.update(
+          (state -> {
+            state.setIvyModules(allModules);
+            return state;
+          }));
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,6 +9,10 @@
 
   <depends>com.intellij.modules.java</depends>
 
+  <projectListeners>
+    <listener class="saigonwithlove.ivy.intellij.settings.IvyModuleListener" topic="com.intellij.openapi.project.ModuleListener"/>
+  </projectListeners>
+  
   <extensions defaultExtensionNs="com.intellij">
     <postStartupActivity implementation="saigonwithlove.ivy.intellij.settings.InitializationActivity"/>
     <projectService serviceImplementation="saigonwithlove.ivy.intellij.settings.PreferenceService"/>


### PR DESCRIPTION
fix #31 
Handle the exception AlreadyDisposedException by register a listener to IntelliJ module listener. When a module is closed, then the listener will remove the module from preference state and update it to prevent error from CellRender